### PR TITLE
fix layer unfreezing Closes #40

### DIFF
--- a/wildlifeml/training/trainer.py
+++ b/wildlifeml/training/trainer.py
@@ -149,7 +149,6 @@ class WildlifeTrainer(BaseTrainer):
                 layer.trainable = False
             for layer in bbone_layers[-self.finetune_layers :]:
                 layer.trainable = True
-            breakpoint()
 
             print('---> Compiling model')
             self.model.compile(


### PR DESCRIPTION
currently, layer access in finetuning is wrong due to structure of sequential object, which has 3 layers (1 - preproc, 2 - core, 3 - dense head) --> unfreezing needs to happen one level deeper in the core